### PR TITLE
Force devcontainer to use vscoq 2.2.3 for coq 8.19

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "image": "owenardenucsc/cse210a:8.19",
   "customizations": {
     "vscode": {
-      "extensions": ["maximedenes.vscoq"],
+      "extensions": ["maximedenes.vscoq@2.2.3"],
       "settings": {
         "coqtop.binPath" : "/home/coq/.opam/default/bin",
         "files.exclude": {


### PR DESCRIPTION
coq 8.19.2 uses vscoq 2.2.3. using 2.2.5 may cause issues so best to keep it at an older version.